### PR TITLE
Added price

### DIFF
--- a/amazonscraper/client.py
+++ b/amazonscraper/client.py
@@ -260,6 +260,15 @@ class Client(object):
                         product_dict['asin'] = asin
 
                         if "slredirect" not in proper_url:  # slredirect = bad url
+                            # Get price using asin
+                            info_url = urljoin(
+                                self.base_url,
+                                f"gp/cart/desktop/ajax-mini-detail.html/ref=added_item_1?ie=UTF8&asin={asin}")
+                            info = self._get(info_url)
+                            soup_info = BeautifulSoup(info.text, _DEFAULT_BEAUTIFULSOUP_PARSER)
+                            price = soup_info.select('span.a-size-medium.a-color-price.sc-price')
+                            product_dict['price'] = price[0].getText()
+
                             self.product_dict_list.append(product_dict)
 
             if len(self.product_dict_list) < max_product_nb:
@@ -301,5 +310,3 @@ images/I/51F48HFHq6L.jpg
     """
     high_res_url = img_url.split("._")[0] + ".jpg"
     return high_res_url
-
-

--- a/amazonscraper/client.py
+++ b/amazonscraper/client.py
@@ -267,7 +267,8 @@ class Client(object):
                             info = self._get(info_url)
                             soup_info = BeautifulSoup(info.text, _DEFAULT_BEAUTIFULSOUP_PARSER)
                             price = soup_info.select('span.a-size-medium.a-color-price.sc-price')
-                            product_dict['price'] = price[0].getText()
+                            if price: # Doesn't work for ebooks
+                                product_dict['price'] = price[0].getText()
 
                             self.product_dict_list.append(product_dict)
 


### PR DESCRIPTION
I found a relatively lightweight way to retrieve pricing info the way some of the price-tracking applications do it :D.
It uses a special path gp/cart/desktop/ajax-mini-detail.html/ref=added_item_1?ie=UTF8&asin=
It works on everything I’ve found except e-books.
It is an extra resource about 3KB to load, so maybe we should make it an optional parameter but it can also be used to get number of ratings, if in stock, seller, etc. (e.g., https://www.amazon.com/gp/cart/desktop/ajax-mini-detail.html/ref=added_item_1?ie=UTF8&asin=1593276036)

I'm pretty confident about this method, and it might even serve us well to get all the info this way since I've noticed images aren't always correct as is.