### PR TITLE
Update extraction of title, price, average rating and number of ratings; other tweaks

### DIFF
--- a/amazonscraper/client.py
+++ b/amazonscraper/client.py
@@ -93,6 +93,7 @@ class Client(object):
                         application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
                     }
         self.product_dict_list = []
+        self.html_pages = []
 
     def _change_user_agent(self):
         """ Change the User agent of the requests
@@ -253,10 +254,11 @@ class Client(object):
         res = None
 
         while trials < _MAX_TRIAL_REQUESTS:
+            print('Trying user agent: {}'.format(self.headers['User-Agent']))
             trials += 1
             try:
                 res = self._get(search_url)
-                # import pdb; pdb.set_trace()
+
                 valid_page = self._check_page(res.text)
 
             # To counter the "SSLError bad handshake" exception
@@ -272,10 +274,7 @@ class Client(object):
             self._change_user_agent()
             time.sleep(_WAIT_TIME_BETWEEN_REQUESTS)
 
-        if res is not None:
-            self.last_html_page = res.text
-        else:
-            self.last_html_page = "Not any good page saved :("
+        self.html_pages.append(res.text)
 
         if not valid_page:
             print('No valid pages found! Perhaps the page returned is a CAPTCHA? Check products.last_html_page')

--- a/amazonscraper/client.py
+++ b/amazonscraper/client.py
@@ -261,6 +261,8 @@ class Client(object):
         """
         Given the HTML of a `product`, extract all prices.
         """
+        # XXX currently does not handle shipping prices or prices for the
+        # various formats of books.
 
         # match all prices of the form $X,XXX.XX:
         raw_prices = product.find_all(text=re.compile('\$[\d,]+.\d\d'))

--- a/amazonscraper/client.py
+++ b/amazonscraper/client.py
@@ -20,7 +20,6 @@ Intel Mac OS X 10_13_5) AppleWebKit/537.36 (KHTML, like Gecko) \
 Chrome/67.0.3396.79 Safari/537.36'
 
 _USER_AGENT_LIST = [
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:66.0) Gecko/20100101 Firefox/66.0',
     _DEFAULT_USER_AGENT,
     _CHROME_DESKTOP_USER_AGENT,
 ]

--- a/test/test_amazonscraper.py
+++ b/test/test_amazonscraper.py
@@ -77,5 +77,7 @@ def test_amazonscraper_csv_header():
     products = amazonscraper.search(
                                 keywords="Python",
                                 max_product_nb=1)
-    assert "Product title,Rating,Number of customer reviews,Product URL,\
-Image URL,ASIN\n" in str(products.csv())
+    products.csv('test.csv')
+    with open('test.csv') as f:
+        csv_str = f.read()
+    assert "title,rating,review_nb,img,url,asin,prices_per_unit,units,prices_main"  in csv_str


### PR DESCRIPTION
Currently, the CSS selectors don't work for title, price, average rating or number of ratings. I use regex to extract price and average rating, which might be more consistent than the CSS selectors. To handle multiple prices, I return the minimum non-zero price, but this could be modified readily. 

I've also taken the liberty of breaking out the extraction of each element into it's own function. I simplified the logic of `Client._get_products` by having an early return after checking `valid_page`, thus the big diff there. I added some comments as well.