### PR TITLE
Updating setup.py to resolve 'AttributeError: 'ParsedRequirement' obj…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,10 @@ _SCRIPTS = ['amazon2csv.py']
 # if no command is used in the package
 
 install_reqs = parse_requirements('requirements.txt', session='hack')
-requirements = [str(ir.req) for ir in install_reqs]
+try:
+    requirements = [str(ir.req) for ir in install_reqs]
+except:
+    requirements = [str(ir.requirement) for ir in install_reqs]
 
 setup(
     name=_NOM_PACKAGE,


### PR DESCRIPTION
…ect has no attribute 'req''

This pull request updates setup.py in order to resolve an error I was observing with pip 20.2.3 where installation would result in the above AttributeError.